### PR TITLE
Changed name to be consistent

### DIFF
--- a/edm4hep.yaml
+++ b/edm4hep.yaml
@@ -363,7 +363,7 @@ datatypes :
       - float dEdxError                  //error of dEdx.
       - float radiusOfInnermostHit       //radius of the innermost hit that has been used in the track fit
     VectorMembers:
-      - int32_t subDetectorHitNumbers        //number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
+      - int32_t subdetectorHitNumbers        //number of hits in particular subdetectors.Check/set collection variable TrackSubdetectorNames for decoding the indices
       - edm4hep::TrackState trackStates  //track states
       - edm4hep::Quantity dxQuantities // different measurements of dx quantities
     OneToManyRelations:


### PR DESCRIPTION
Changed the name of one VectorMember of edm4hep::track from subDetectorHitNumbers to subdetectorHitNumbers to be consistent with other spellings of the subdetector in the yaml and in lcio.



